### PR TITLE
refactor: modernize legacy Moviepilot scripts

### DIFF
--- a/legacy/Mp-Cleanup.user.js
+++ b/legacy/Mp-Cleanup.user.js
@@ -1,98 +1,105 @@
 // ==UserScript==
-// @name                MP-Cleanup (jQuery)
+// @name                MP-Cleanup
 // @description         Moviepilot generell bereinigen
 // @author              mitcharts, leinzi
 // @grant               none
 // @downloadURL         https://raw.githubusercontent.com/Leinzi/mp-Skripte/master/Mp-Cleanup.user.js
-// @require             https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js
 // @include             /^(https?:)\/\/(.+\.)?(moviepilot.de)\/(.*)$/
 // @exclude             /^(https?:)\/\/(.+\.)?(moviepilot.de)\/serie\/(.*)$/
-// @version             1.1.0
+// @version             1.2.0
 // ==/UserScript==
 
-// jQuery-Konflikte loesen
-this.$ = this.jQuery = jQuery.noConflict(true);
+if (document.readyState !== 'loading') {
+  init();
+} else {
+  document.addEventListener('DOMContentLoaded', init);
+}
 
-// Funktion, damit das Dokument erst fertig geladen wird
-$(document).ready(function(){
-
-  // Variablendefinitionen
-  // Hinweis: 'i' wird bewusst ausgelassen
-  var communitybox = $(".banner--vdt");
-  var separatorssidebar = $(".seperators");
-  var subsocial = $(".navigation--sub--social");
-  var themensidebar = $(".lists--timeline");
-  var vormerkbox = $(".widget--followships");
-
-  var getURL = window.location.href.replace('.html', '');
-
+function init() {
   cleanUpHeader();
   cleanUpFooter();
   cleanUpSidebar();
   cleanUpMiddleBar();
   cleanUpMainPage();
-
   justifyTextContent();
-
-});
-
-function cleanUpMiddleBar(){
-  var recentNews = $(".article--footer-elements > .cards--grid");
-  recentNews.remove();
-  var newsKeywords = $(".keywords");
-  //newsKeywords.remove();
-  var adNews = $(".article--article-advertising");
-  adNews.remove();
-  var socialMediaBar = $(".article--social-header-bar--share");
-  socialMediaBar.remove();
-  var newsShopping = $(".js--consumptions--widget-poster");
-  newsShopping.remove();
 }
 
-function cleanUpSidebar(){
-  var sidebarWerbung = $('#ad-rectangle1-outer');
-  sidebarWerbung.remove();
-  var sidebarTrending = $(".lists--toplist");
-  //sidebarTrending.remove();
-  var sidebarWerbung2 = $(".advertisement--medium-rectangle");
-  sidebarWerbung2.remove();
-  var sidebarNews = $(".news-sidebar");
-  sidebarNews.remove();
-  var sidebarVideo = $(".showheroes--sidebar");
-  sidebarVideo.remove();
-  var sidebarShopping = $(".consumptions--widget-list--items");
-  sidebarShopping.remove();
+function cleanUpMiddleBar() {
+  const recentNews = document.querySelector('.article--footer-elements > .cards--grid');
+  if (recentNews) recentNews.remove();
+
+  const newsKeywords = document.querySelector('.keywords');
+  // if (newsKeywords) newsKeywords.remove();
+
+  const adNews = document.querySelector('.article--article-advertising');
+  if (adNews) adNews.remove();
+
+  const socialMediaBar = document.querySelector('.article--social-header-bar--share');
+  if (socialMediaBar) socialMediaBar.remove();
+
+  const newsShopping = document.querySelector('.js--consumptions--widget-poster');
+  if (newsShopping) newsShopping.remove();
 }
 
-function cleanUpFooter(){
-  var footerVideo = $(".video--player--footer");
-  footerVideo.remove();
-  var footerLinks = $(".footer_ng--secondary");
-  footerLinks.remove();
-  var footerElements = $('article--footer-elements');
-  footerElements.remove();
+function cleanUpSidebar() {
+  const sidebarWerbung = document.querySelector('#ad-rectangle1-outer');
+  if (sidebarWerbung) sidebarWerbung.remove();
+
+  const sidebarTrending = document.querySelector('.lists--toplist');
+  // if (sidebarTrending) sidebarTrending.remove();
+
+  const sidebarWerbung2 = document.querySelector('.advertisement--medium-rectangle');
+  if (sidebarWerbung2) sidebarWerbung2.remove();
+
+  const sidebarNews = document.querySelector('.news-sidebar');
+  if (sidebarNews) sidebarNews.remove();
+
+  const sidebarVideo = document.querySelector('.showheroes--sidebar');
+  if (sidebarVideo) sidebarVideo.remove();
+
+  const sidebarShopping = document.querySelector('.consumptions--widget-list--items');
+  if (sidebarShopping) sidebarShopping.remove();
 }
 
-function cleanUpHeader(){
-  var headerBanner = $("#ads-outer");
-  headerBanner.remove();
+function cleanUpFooter() {
+  const footerVideo = document.querySelector('.video--player--footer');
+  if (footerVideo) footerVideo.remove();
+
+  const footerLinks = document.querySelector('.footer_ng--secondary');
+  if (footerLinks) footerLinks.remove();
+
+  const footerElements = document.querySelector('article--footer-elements');
+  if (footerElements) footerElements.remove();
+}
+
+function cleanUpHeader() {
+  const headerBanner = document.querySelector('#ads-outer');
+  if (headerBanner) headerBanner.remove();
 }
 
 function cleanUpMainPage() {
-  var topTrailer = $(".home--trailer-slider");
-  topTrailer.remove();
-  var topRecommendation = $("#home_personal_recommendations");
-  topRecommendation.remove();
+  const topTrailer = document.querySelector('.home--trailer-slider');
+  if (topTrailer) topTrailer.remove();
+
+  const topRecommendation = document.querySelector('#home_personal_recommendations');
+  if (topRecommendation) topRecommendation.remove();
 }
 
-function justifyTextContent(){
-  // News-Artikel
-  $('.article--content-wrapper').css({'margin': '40px 0 0 0', 'text-align': 'justify'});
-  // Filmdetailseiten
-  $('.movie--summary').css({'text-align': 'justify'});
-  // Kommentare
-  $('.js--comments').css({'text-align': 'justify'});
-  // Darstellerübersicht
-  $('.person--description').css({'text-align': 'justify'});
+function justifyTextContent() {
+  document.querySelectorAll('.article--content-wrapper').forEach((el) => {
+    el.style.margin = '40px 0 0 0';
+    el.style.textAlign = 'justify';
+  });
 
+  document.querySelectorAll('.movie--summary').forEach((el) => {
+    el.style.textAlign = 'justify';
+  });
+
+  document.querySelectorAll('.js--comments').forEach((el) => {
+    el.style.textAlign = 'justify';
+  });
+
+  document.querySelectorAll('.person--description').forEach((el) => {
+    el.style.textAlign = 'justify';
+  });
 }

--- a/legacy/mp-fonts.user.js
+++ b/legacy/mp-fonts.user.js
@@ -5,9 +5,8 @@
 // @grant               none
 // #downloadURL         https://github.com/Leinzi/mp-Skripte/raw/master/mp-fonts.user.js
 // @include             /^https?:\/\/www\.moviepilot.de\//
-// @version             0.0.2
+// @version             0.0.3
 // ==/UserScript==
-
 
 if (document.readyState !== 'loading') {
   performCleanUp();
@@ -16,42 +15,36 @@ if (document.readyState !== 'loading') {
 }
 
 function performCleanUp() {
-  loadOriginalFonts()
+  loadOriginalFonts();
   loadFonts();
-  //improveFonts();
+  // improveFonts();
 }
 
 // ----- Improvements - Anfang -----
-function loadOriginalFonts() {
-  let html = document.querySelector('html');
-  html.classList.add('wf-notosans-n4-active')
-  html.classList.add('wf-notoserif-n4-active')
-  html.classList.add('wf-notoserif-i4-active')
-  html.classList.add('wf-oswald-n4-active')
-  html.classList.add('wf-oswald-n5-active')
-  html.classList.add('wf-oswald-n6-active')
-  html.classList.add('wf-active')
-}
+const loadOriginalFonts = () => {
+  const html = document.documentElement;
+  html.classList.add(
+    'wf-notosans-n4-active',
+    'wf-notoserif-n4-active',
+    'wf-notoserif-i4-active',
+    'wf-oswald-n4-active',
+    'wf-oswald-n5-active',
+    'wf-oswald-n6-active',
+    'wf-active'
+  );
+};
 
-function loadFonts() {
-  let fonts = document.createElement('link');
+const loadFonts = () => {
+  const fonts = document.createElement('link');
   fonts.href = 'https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Roboto:ital,wght@0,400;0,500;0,700;1,400&family=Noto+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap';
-  fonts.rel = "stylesheet";
-  document.getElementsByTagName('head')[0].appendChild(fonts);
-}
+  fonts.rel = 'stylesheet';
+  document.head.append(fonts);
+};
 
-function improveFonts() {
-  let style = document.createElement('style');
-  style.type = 'text/css';
-
-  let improvements = 'html,body * { font-family: "Roboto", serif !important; } h1,h2,h3,h4,h5,h6 { font-family: "Oswald", serif !important; }'
-
-  if (style.styleSheet) {
-    style.styleSheet.cssText = improvements;
-  } else {
-    style.appendChild(document.createTextNode(improvements));
-  }
-  document.getElementsByTagName('head')[0].appendChild(style);
-}
+const improveFonts = () => {
+  const style = document.createElement('style');
+  style.textContent = 'html,body * { font-family: "Roboto", serif !important; } h1,h2,h3,h4,h5,h6 { font-family: "Oswald", serif !important; }';
+  document.head.append(style);
+};
 
 // ----- Improvements - Ende -----

--- a/legacy/mp-no-relevant-links.user.js
+++ b/legacy/mp-no-relevant-links.user.js
@@ -4,14 +4,22 @@
 // @description   Bilderstrecken auf Moviepilot umgehen
 // @grant         none
 // @downloadURL   https://raw.githubusercontent.com/Leinzi/mp-Skripte/master/mp-no-relevant-links.user.js
-// @require       https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js
 // @include       /^(https?:\/\/www\.moviepilot.de\/news)(\?page=([1-9][0-9]*))?$/
-// @version       0.1.4
+// @version       0.1.5
 // ==/UserScript==
 
+if (document.readyState !== 'loading') {
+  hideRelevantLinks();
+} else {
+  document.addEventListener('DOMContentLoaded', hideRelevantLinks);
+}
 
-// Funktion, damit das Dokument erst fertig geladen wird
-$(document).ready(function(){
-  var linkParagraphs = $('p:contains("Relevante Links")');
-  linkParagraphs.hide();
-});
+function hideRelevantLinks() {
+  document
+    .querySelectorAll('p')
+    .forEach((p) => {
+      if (p.textContent.includes('Relevante Links')) {
+        p.style.display = 'none';
+      }
+    });
+}


### PR DESCRIPTION
## Summary
- replace jQuery-dependent logic with modern DOM and fetch APIs in `mp-avoid-clickgal`
- drop jQuery requirement and use native DOM operations in `mp-no-relevant-links`
- remove jQuery dependency and streamline clean-up logic in `Mp-Cleanup`
- refresh `mp-fonts` with arrow functions and `document.head` usage

## Testing
- `npm test`
- `node --check legacy/mp-avoid-clickgal.user.js`
- `node --check legacy/mp-no-relevant-links.user.js`
- `node --check legacy/Mp-Cleanup.user.js`
- `node --check legacy/mp-fonts.user.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2be459e3c8326bd8e020d2043e668